### PR TITLE
fix: corrigir erro na função realizar_plantacao

### DIFF
--- a/src/core/farmActions.py
+++ b/src/core/farmActions.py
@@ -1,7 +1,5 @@
-import pyautogui
-import time
-import random
-from src.utils.config import spots_colheita, spotPlantacao, posicaoMontaria, slot_itens, posicionamentoIlha
+import pyautogui, time, random
+from src.utils.config import spots_colheita, spots_plantacao, posicaoMontaria, slot_itens, posicionamentoIlha
 
 pyautogui.FAILSAFE = True
 
@@ -23,11 +21,11 @@ def prepararSemente():
     pyautogui.click(1676, 540, duration=0.6)
     pyautogui.click(822, 427, duration=0.6)
 
-#Função de plantar as sementes nos 9 slots de cada terreno
+
 def realizarPlantacao(indiceTerreno):
     print(f"Plantando no terreno {indiceTerreno + 1}...")
     
-    for x, y in spotPlantacao:
+    for x, y in spots_plantacao:
         pyautogui.click(x, y, duration=0.3)
         time.sleep(0.6)
 

--- a/src/navigation/movement.py
+++ b/src/navigation/movement.py
@@ -1,5 +1,4 @@
-import pyautogui
-import time
+import pyautogui, time
 
 #Função de caminhar entre os terrenos de acordo com as coordenadas passadas na lista e sublistas da lista caminhosTerrenos
 def navegarTerreno(listaCliques):

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -22,11 +22,11 @@ slot_itens = [
     (1735, 602), (124, 466),      #Guardar itens do slot 6 do inventário
 ]
 
-#Posições da montaria
+
 #Foi necessário definir as coordenadas nesse formato no lugar de um loop com uma coordenada fixa, pois a montaria 
 #varia o posicionamento de acordo com o terreno de colheita
 posicaoMontaria = [
-    [(942,829), (966, 400)],    #1
+    [(942,829), (966, 400)],   #1
     [(942, 825), (986, 409)],  #2
     [(942, 830), (976, 391)],  #3
     [(942, 829), (989, 408)],  #4
@@ -45,10 +45,10 @@ posicaoMontaria = [
 ]
 
 #Slots de plantação
-spotPlantacao = [
+spots_plantacao = [
     (817, 522), (941, 645), (1007, 437),
     (1091, 506), (1086, 329), (1191, 409),
-    (1340, 514), (1216, 605), (1082, 701)
+    (1340, 514), (1216, 605), (1084, 895)
 ]
 
 # MAPA DE NAVEGAÇÃO


### PR DESCRIPTION
O que foi feito?

Fix: correção do erro que ocorria no momento que a função realizar_plantacao tentava plantar sementes no 9º spot dos terrenos.

Foi mapeado uma nova coordenada X e Y para a lista spots_plantacao com o intuito de corrigir essa falha.